### PR TITLE
Fixed mostRecentSequence in NetcodeReplayProtection

### DIFF
--- a/Netcode.IO.NET/Core/NetcodeReplayProtection.cs
+++ b/Netcode.IO.NET/Core/NetcodeReplayProtection.cs
@@ -39,6 +39,9 @@
 			if (sequence + NETCODE_REPLAY_PROTECTION_BUFFER_SIZE <= mostRecentSequence)
 				return true;
 
+			if (sequence > mostRecentSequence)
+				mostRecentSequence = sequence;
+
 			int index = (int)(sequence % NETCODE_REPLAY_PROTECTION_BUFFER_SIZE);
 			if (receivedPackets[index] == 0xFFFFFFFFFFFFFFFF)
 			{


### PR DESCRIPTION
Reference:
https://github.com/networkprotocol/netcode.io/blob/c89108e2c18d486b4b6e875c949f5e4d8ce6e692/netcode.c#L1548