### PR TITLE
Fix for IPv6 Support

### DIFF
--- a/Netcode.IO.NET/Core/ConnectTokenData.cs
+++ b/Netcode.IO.NET/Core/ConnectTokenData.cs
@@ -24,8 +24,8 @@ namespace NetcodeIO.NET
 		{
 			byte addressVal = stream.ReadByte();
 
-			// if address type is not 0 or 1, data is not valid
-			if (addressVal != 0 && addressVal != 1)
+			// if address type is not 1 or 2, data is not valid
+			if (addressVal != 1 && addressVal != 2)
 				throw new FormatException();
 
 			this.AddressType = (NetcodeAddressType)addressVal;

--- a/Netcode.IO.NET/Core/DatagramQueue.cs
+++ b/Netcode.IO.NET/Core/DatagramQueue.cs
@@ -28,6 +28,13 @@ namespace NetcodeIO.NET.Utils
 		private object datagram_mutex = new object();
 		private object endpoint_mutex = new object();
 
+		private IPAddress defaultAnyAddress;
+
+		public DatagramQueue(IPAddress defaultAnyAddress)
+		{
+			this.defaultAnyAddress = defaultAnyAddress;
+		}
+
 		public int Count
 		{
 			get
@@ -51,7 +58,7 @@ namespace NetcodeIO.NET.Utils
 				if (endpointPool.Count > 0)
 					sender = endpointPool.Dequeue();
 				else
-					sender = new IPEndPoint(IPAddress.Any, 0);
+					sender = new IPEndPoint(defaultAnyAddress, 0);
 			}
 
 			byte[] receiveBuffer = BufferPool.GetBuffer(2048);

--- a/Netcode.IO.NET/Utils/IO/SocketContext.cs
+++ b/Netcode.IO.NET/Utils/IO/SocketContext.cs
@@ -37,7 +37,7 @@ namespace NetcodeIO.NET.Utils.IO
 
 		public UDPSocketContext(AddressFamily addressFamily)
 		{
-			datagramQueue = new DatagramQueue();
+			datagramQueue = new DatagramQueue(addressFamily == AddressFamily.InterNetwork ? IPAddress.Any : IPAddress.IPv6Any);
 			internalSocket = new Socket(addressFamily, SocketType.Dgram, ProtocolType.Udp);
 		}
 
@@ -182,7 +182,7 @@ namespace NetcodeIO.NET.Utils.IO
 
 		private EndPoint endpoint;
 		private List<simulatedPacket> simulatedPackets = new List<simulatedPacket>();
-		private DatagramQueue datagramQueue = new DatagramQueue();
+		private DatagramQueue datagramQueue = new DatagramQueue(IPAddress.Any);
 		private object mutex = new object();
 
 		private Random rand = new Random();


### PR DESCRIPTION
This enables a client to connect to an IPv6 host thanks to two fixes:
- token validation fix
- listen on an IP address of the correct family in the DatagramQueue